### PR TITLE
Export set-display-flag

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -149,7 +149,7 @@
    ;; Display Settings
    #:get-display-flags
    #:get-display-flag
-   #:toggle-display-flag
+   #:set-display-flag
    #:get-display-option
    #:get-display-format
    #:get-display-refresh-rate


### PR DESCRIPTION
`#:set-display-flag` was not exported, but `#:toggle-display-flag` (which does not correspond to any function) was. This change replaces the export with `#:set-display flag`.